### PR TITLE
Migrate Travis tests to dep, too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ jobs:
   include:
     - stage: test
       before_install:
-        - go get -u github.com/Masterminds/glide
+        - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
         - go get -u github.com/alecthomas/gometalinter
       install:
-        - glide install
+        - dep ensure
         - gometalinter --install
       script:
         - ./scripts/test.sh


### PR DESCRIPTION
This is a follow on from https://github.com/planetlabs/draino/pull/18, which updated the Docker build but not the Travis tests.

We should probably consider running the tests in a Docker container for environmental consistency at some point.