### PR TITLE
don't build the image twice

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 VERSION=$(git rev-parse --short HEAD)
-docker build --tag "planetlabs/draino:latest" .
 docker build --tag "planetlabs/draino:${VERSION}" .
+docker tag "planetlabs/draino:${VERSION}" "planetlabs/draino:latest"


### PR DESCRIPTION
Just build it once and retag the latest image using the VERSION just built. Also fail the script on errors.