### PR TITLE
support for other condition state than true

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -60,7 +60,7 @@ func main() {
 
 		protectedPodAnnotations = app.Flag("protected-pod-annotation", "Protect pods with this annotation from eviction. May be specified multiple times.").PlaceHolder("KEY[=VALUE]").Strings()
 
-		conditions = app.Arg("node-conditions", "Nodes for which any of these conditions are true will be cordoned and drained.").Required().Strings()
+		conditions = app.Arg("node-conditions", "Nodes for which any of these conditions are true will be cordoned and drained. <TYPE[=STATE]>").Strings()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	glogWorkaround()


### PR DESCRIPTION
Bring support for false and unknown node condition statuses.
Changes ment to be backward compatible.

If run `draino OutOfDisk OutOfDisk=Unknown` it will allow draino to cordone and drain nodes that will match OutOfDisk = True and OutOfDisk = Unknown condition statuses 
