### PR TITLE
add a simple log line prior to main run loop

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -142,6 +142,7 @@ func main() {
 	lf := cache.FilteringResourceEventHandler{FilterFunc: kubernetes.NewNodeLabelFilter(*nodeLabels), Handler: cf}
 	nodes := kubernetes.NewNodeWatch(cs, lf)
 
+	log.Info("draino is running", zap.String("listen", *listen))
 	kingpin.FatalIfError(await(nodes, web), "error serving")
 }
 


### PR DESCRIPTION
Some folks would like to see some log output to sanity that draino has started up.