### PR TITLE
Support more values and status duration for condition

### DIFF
--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -91,6 +91,13 @@ type APICordonDrainer struct {
 	evictionHeadroom time.Duration
 }
 
+// SuppliedCondition defines the condition will be watched.
+type SuppliedCondition struct {
+	Type            core.NodeConditionType
+	Status          core.ConditionStatus
+	MinimumDuration time.Duration
+}
+
 // APICordonDrainerOption configures an APICordonDrainer.
 type APICordonDrainerOption func(d *APICordonDrainer)
 


### PR DESCRIPTION
The attribute LastTransitionTime of NodeCondition indicates that last
time the condition transit from one status to another, so it's very
useful to be leveraged to track how long a node is in a particular
state.

Meanwhile, a new backward-compatible condition format is introduced
so support more values and the status duration for condition as below:

OutOfDisk=True,10m

That means when condition OutOfDisk equals True and the state needs
to be on that status at least 10 mins. And the old format is still
supported. When a simple condition, e.g. KernelDeadlock, is passed in,
it will be parsed as *KernelDeadlock=True,0* to keep the backward
compatibility.

Note that the value after comma can be any string which can be parsed
by time.ParseDuration, e.g. 30s, 10m, etc.

fixes #33 