### PR TITLE
WIP: Attempt at cordon but no drain

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,11 @@ draino_cordoned_nodes_total{result="failed"} 1
 draino_drained_nodes_total{result="succeeded"} 1
 draino_drained_nodes_total{result="failed"} 1
 ```
+
+## Modes
+
+### Dry Run
+Draino can be run in dry run mode using the `--dry-run` flag.
+
+### Cordon Only
+Draino can also optionally be run in a mode where the nodes are only cordoned, and not drained. This can be achieved by using the `--no-drain` flag


### PR DESCRIPTION
This is an attempt at setting an option which will cordon the nodes, but not drain them.

Some workloads, for example workloads that use a lot of `kind: Job` will eventually have nodes cleared out on their own. By specifying a flag `--no-drain` and using this method, we can cordon the nodes so new workloads don't appear.

I'm not the best Go programmer, so any feedback or suggestions would be greatly welcomed.