### PR TITLE
helm: fix indentation level for initialDelaySeconds in probe

### DIFF
--- a/helm/draino/templates/deployment.yaml
+++ b/helm/draino/templates/deployment.yaml
@@ -35,10 +35,10 @@ spec:
             - {{ . }}
           {{- end }}
           livenessProbe:
+            initialDelaySeconds: 30
             httpGet:
               path: /healthz
               port: 10002
-              initialDelaySeconds: 30
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "draino.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}


### PR DESCRIPTION
The `initialDelaySeconds` entry should be configured inside the `livenessProbe` entry and not inside `httpGet`. Trying to apply the helm chart as it was would cause an error similar to:

```
error: error validating "deployment.yaml": error validating data: ValidationError(Deployment.spec.template.spec.containers[0].livenessProbe.httpGet): unknown field "initialDelaySeconds" in io.k8s.api.core.v1.HTTPGetAction; if you choose to ignore these errors, turn validation off with --validate=false
```

This PR simply moves `initialDelaySeconds` to the right place.
