### PR TITLE
Add leader election to ensure only one node handler is running

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -471,7 +471,7 @@
   version = "kubernetes-1.11.0"
 
 [[projects]]
-  digest = "1:79cf4c5cf3e201879a15cfb4146adeb33301c0c241bbd3cf70de08bb25cd57f8"
+  digest = "1:bc85bb7df6e71402fa431b26ac70461c15a52a70d1cbff776cb7d0a8fc486301"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -551,6 +551,8 @@
     "tools/clientcmd/api",
     "tools/clientcmd/api/latest",
     "tools/clientcmd/api/v1",
+    "tools/leaderelection",
+    "tools/leaderelection/resourcelock",
     "tools/metrics",
     "tools/pager",
     "tools/record",
@@ -608,6 +610,8 @@
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
+    "k8s.io/client-go/tools/leaderelection",
+    "k8s.io/client-go/tools/leaderelection/resourcelock",
     "k8s.io/client-go/tools/record",
   ]
   solver-name = "gps-cdcl"

--- a/helm/draino/templates/clusterrole.yaml
+++ b/helm/draino/templates/clusterrole.yaml
@@ -27,5 +27,8 @@ rules:
 - apiGroups: [extensions]
   resources: [daemonsets]
   verbs: [get, watch, list]
+- apiGroups: ['']
+  resources: [endpoints]
+  verbs: [get, create, update]
 
 {{- end -}}


### PR DESCRIPTION
This PR fixes the issue #39 by implementing leader election for the node watcher and its handlers.

A non-leader process will freeze waiting for it to become leader before starting the node watcher. If we loose an election after we're already leader we'll simply kill the process and let kubernetes restart it, this is a common pattern seen in controllers in the wild.

The web server handler is started before leader election to allow metrics and healthcheck even for non-leaders.

Closes #39