### PR TITLE
take into account key/value with empty value for node label selector

### DIFF
--- a/internal/kubernetes/nodefilters.go
+++ b/internal/kubernetes/nodefilters.go
@@ -33,7 +33,7 @@ func NewNodeLabelFilter(labels map[string]string) func(o interface{}) bool {
 			return false
 		}
 		for k, v := range labels {
-			if n.GetLabels()[k] != v {
+			if value, ok := n.GetLabels()[k]; value != v || !ok {
 				return false
 			}
 		}

--- a/internal/kubernetes/nodefilters_test.go
+++ b/internal/kubernetes/nodefilters_test.go
@@ -116,6 +116,17 @@ func TestNodeLabelFilter(t *testing.T) {
 			passesFilter: false,
 		},
 		{
+			name: "FilterWithEmptyValueAndNodeWithEmptyValue",
+			obj: &core.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name:   nodeName,
+					Labels: map[string]string{"cool": "very", "keyWithNoValue": ""},
+				},
+			},
+			labels:       map[string]string{"keyWithNoValue": ""},
+			passesFilter: true,
+		},
+		{
 			name: "NotANode",
 			obj: &core.Pod{
 				ObjectMeta: meta.ObjectMeta{

--- a/internal/kubernetes/nodefilters_test.go
+++ b/internal/kubernetes/nodefilters_test.go
@@ -105,6 +105,17 @@ func TestNodeLabelFilter(t *testing.T) {
 			passesFilter: true,
 		},
 		{
+			name: "FilterWithEmptyValue",
+			obj: &core.Node{
+				ObjectMeta: meta.ObjectMeta{
+					Name:   nodeName,
+					Labels: map[string]string{"cool": "very"},
+				},
+			},
+			labels:       map[string]string{"keyWithNoValue": ""},
+			passesFilter: false,
+		},
+		{
 			name: "NotANode",
 			obj: &core.Pod{
 				ObjectMeta: meta.ObjectMeta{


### PR DESCRIPTION
If the --node-label=KEY=VALUE  comes with a VALUE that is empty the node selection is failing and return all nodes. This PR limits the scope to the node that hold a label with the given KEY with an empty VALUE.

