### PR TITLE
correction to addgroup / user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go build -o /draino ./cmd/draino
 
 FROM alpine:3.10
 
-RUN apk update && apk add ca-certificates \
-    && RUN addgroup -S user && adduser -S user -G user
+RUN apk update && apk add ca-certificates
+RUN addgroup -S user && adduser -S user -G user
 USER user
 COPY --from=build /draino /draino


### PR DESCRIPTION
Container builds have been failing since 26dcd6b2. Somewhat easy to miss in MR's because we don't build until master.
