### PR TITLE
[helm] Add securityContext and update default image tag

### DIFF
--- a/helm/draino/templates/deployment.yaml
+++ b/helm/draino/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "draino.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/draino/values.yaml
+++ b/helm/draino/values.yaml
@@ -38,3 +38,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Security Context policies for pods
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext: {}

--- a/helm/draino/values.yaml
+++ b/helm/draino/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: planetlabs/draino
-  tag: 5e07e93
+  tag: 2c3d2b4
   pullPolicy: IfNotPresent
 
 resources:
@@ -41,4 +41,8 @@ affinity: {}
 
 # Security Context policies for pods
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-securityContext: {}
+securityContext:
+  fsGroup: 101
+  runAsGroup: 101
+  runAsNonRoot: true
+  runAsUser: 100


### PR DESCRIPTION
This Pull Request updates the default image tag to the latest at this moment and also adds a new value `securityContext`, so users can customize draino to run as non-root properly.

The default securityContext parameters are working out-of-box with the specified image tag, `2c3d2b4 `, so there are no breaking changes.

It is also important from the security perspective, as now drain will run as non-root.