### PR TITLE
initalize klog properly

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/klog"
 
 	"github.com/planetlabs/draino/internal/kubernetes"
 )
@@ -75,6 +76,9 @@ func main() {
 		conditions = app.Arg("node-conditions", "Nodes for which any of these conditions are true will be cordoned and drained.").Required().Strings()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	// this is required to make all packages using klog write to stderr instead of tmp files
+	klog.InitFlags(nil)
 
 	var (
 		nodesCordoned = &view.View{


### PR DESCRIPTION
Fixes https://github.com/planetlabs/draino/issues/79

Summary:
- Draino uses k8s.io/api and k8s.io/apimachinery which both import k8s.io/klog
- By default klog writes logs to tmp files (unless initialized properly)
- klog has an init function that replaces writing to log files with stderr globally (InitFlags)