### PR TITLE
Move invalid pod security context fields in helm chart to container security context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,25 @@ go:
 jobs:
   include:
     - stage: test
+      name: go tests
+      script:
+        - ./scripts/test.sh
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)
+    - stage: test
+      name: go lint
       install:
         - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.24.0
       script:
-        - ./scripts/test.sh
         - ./bin/golangci-lint run --timeout 5m --exclude "\.pb.*\.go" --exclude "_strings\.go" --exclude "_test\.go" --exclude "not checked.+Close" ./...
-      after_success:
-        - bash <(curl -s https://codecov.io/bash)
+    - stage: test
+      name: helm check
+      install:
+        - curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+        - curl -LO https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz
+        - tar xf kubeval-linux-amd64.tar.gz
+      script:
+        - helm template ./helm/draino/ | ./kubeval --strict
     - stage: push
       install: skip
       script:

--- a/helm/draino/templates/deployment.yaml
+++ b/helm/draino/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
               port: 10002
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "draino.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
       {{- with .Values.securityContext }}
       securityContext:

--- a/helm/draino/values.yaml
+++ b/helm/draino/values.yaml
@@ -46,5 +46,7 @@ securityContext:
   runAsGroup: 101
   runAsNonRoot: true
   runAsUser: 100
+
+containerSecurityContext:
   privileged: false
   readOnlyRootFilesystem: true


### PR DESCRIPTION
The `privileged` and `readOnlyRootFilesystem` fields recently added to the Helm chart are not valid in the pod's security context and can only be used in the container's security context. Trying to apply the generated resource would cause the error:

```
error validating data: [ValidationError(Deployment.spec.template.spec.securityContext): unknown field "privileged" in io.k8s.api.core.v1.PodSecurityContext, ValidationError(Deployment.spec.template.spec.securityContext): unknown field "readOnlyRootFilesystem" in io.k8s.api.core.v1.PodSecurityContext]; if you choose to ignore these errors, turn validation off with --validate=false
```

This PR creates a new section in the helm values for container specific security context flags. It also includes a new CI job to validate helm generated resources to help prevent this kind of error in the future.