### PR TITLE
leaderElection token name as parameter

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -64,6 +64,7 @@ func main() {
 		leaderElectionLeaseDuration = app.Flag("leader-election-lease-duration", "Lease duration for leader election.").Default(DefaultLeaderElectionLeaseDuration.String()).Duration()
 		leaderElectionRenewDeadline = app.Flag("leader-election-renew-deadline", "Leader election renew deadline.").Default(DefaultLeaderElectionRenewDeadline.String()).Duration()
 		leaderElectionRetryPeriod   = app.Flag("leader-election-retry-period", "Leader election retry period.").Default(DefaultLeaderElectionRetryPeriod.String()).Duration()
+		leaderElectionTokenName   = app.Flag("leader-election-token-name", "Leader election token name.").Default(kubernetes.Component).String()
 
 		skipDrain             = app.Flag("skip-drain", "Whether to skip draining nodes after cordoning.").Default("false").Bool()
 		evictDaemonSetPods    = app.Flag("evict-daemonset-pods", "Evict pods that were created by an extant DaemonSet.").Bool()
@@ -186,7 +187,7 @@ func main() {
 	lock, err := resourcelock.New(
 		resourcelock.EndpointsResourceLock,
 		*namespace,
-		kubernetes.Component,
+		*leaderElectionTokenName,
 		cs.CoreV1(),
 		cs.CoordinationV1(),
 		resourcelock.ResourceLockConfig{

--- a/go.mod
+++ b/go.mod
@@ -32,4 +32,5 @@ require (
 	k8s.io/api v0.0.0-20190819141258-3544db3b9e44
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v8.0.0+incompatible
+	k8s.io/klog v0.3.1
 )


### PR DESCRIPTION
In some cases we may have to run multiple draino because we need different configuration. (See #62)
In case the different instances run in the same namespace they may conflict on the leader election token.

This PR allows to specify a name for the leaderElection lock resource via program parameter.