### PR TITLE
tune golang-ci lint for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
       install:
         - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.24.0
       script:
-        - ./bin/golangci-lint run --timeout 5m --exclude "\.pb.*\.go" --exclude "_strings\.go" --exclude "_test\.go" --exclude "not checked.+Close" ./...
+        - GOGC=10 ./bin/golangci-lint run -j 4 --timeout 5m --exclude "\.pb.*\.go" --exclude "_strings\.go" --exclude "_test\.go" --exclude "not checked.+Close" ./...
     - stage: test
       name: helm check
       install:


### PR DESCRIPTION
* Increase GC frequency: https://golangci-lint.run/usage/performance/#memory-usage
* Halve the concurrency from its default of 8.