### PR TITLE
use apps/v1 apigroup for DaemonSets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.9-alpine3.11 AS build
+FROM golang:1.13.15-alpine3.11 AS build
 
 RUN apk update && apk add git && apk add curl
 

--- a/helm/draino/templates/clusterrole.yaml
+++ b/helm/draino/templates/clusterrole.yaml
@@ -24,7 +24,7 @@ rules:
 - apiGroups: ['']
   resources: [pods/eviction]
   verbs: [create]
-- apiGroups: [extensions]
+- apiGroups: [apps]
   resources: [daemonsets]
   verbs: [get, watch, list]
 - apiGroups: ['*']

--- a/internal/kubernetes/podfilters.go
+++ b/internal/kubernetes/podfilters.go
@@ -71,7 +71,7 @@ func NewDaemonSetPodFilter(client kubernetes.Interface) PodFilterFunc {
 
 		// Pods pass the filter if they were created by a DaemonSet that no
 		// longer exists.
-		if _, err := client.ExtensionsV1beta1().DaemonSets(p.GetNamespace()).Get(c.Name, meta.GetOptions{}); err != nil {
+		if _, err := client.AppsV1().DaemonSets(p.GetNamespace()).Get(c.Name, meta.GetOptions{}); err != nil {
 			if apierrors.IsNotFound(err) {
 				return true, nil
 			}


### PR DESCRIPTION
Kubernetes stopped serving (removed) extensions apigroup for DaemonSet resource, since v1.16.0 release, which is almost since a year.

DaemonSets are available under apps/v1 groups since v1.9.0 release. So, this should work on both older clusters and also newer clusters without extensions/v1 group.

@jacobstr 