### PR TITLE
remove draino:latest builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,13 @@ Keep the following in mind before deploying Draino:
   [cluster-autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node)
 
 ## Deployment
+
 Draino is automatically built from master and pushed to the [Docker Hub](https://hub.docker.com/r/planetlabs/draino/).
-Builds are tagged `planetlabs/draino:latest` and `planetlabs/draino:$(git rev-parse --short HEAD)`.
+Builds are tagged `planetlabs/draino:$(git rev-parse --short HEAD)`.
+
+**Note:** As of September, 2020 we no longer publish `planetlabs/draino:latest`
+in order to encourage explicit and pinned releases.
+
 An [example Kubernetes deployment manifest](manifest.yml) is provided.
 
 ## Monitoring

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,4 +4,4 @@ set -e
 
 VERSION=$(git rev-parse --short HEAD)
 docker build --tag "planetlabs/draino:${VERSION}" .
-docker tag "planetlabs/draino:${VERSION}" "planetlabs/draino:latest"
+docker tag "planetlabs/draino:${VERSION}"

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -3,5 +3,4 @@
 set -e
 
 VERSION=$(git rev-parse --short HEAD)
-docker push "planetlabs/draino:latest"
 docker push "planetlabs/draino:${VERSION}"


### PR DESCRIPTION
Using `:latest` is often an anti-pattern so lets nip it now. There are a
few MR's that have been in the bike-shed due to concerns of regressions.
Given what `draino` does, a bug that makes it through review,
testing, and lands on an unsuspecting cluster, would be painful.