### PR TITLE
filter out pod in eviction using pod ownerreference kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ An example of `--node-label-expr`:
 
 ### Ignore pod controlled by ...
 It is possible to prevent eviction of pods that are under control of:
-- daemonset
-- statefulset
+- DaemonSet
+- StatefulSet
 - Custom Resource
 - ...
 
-or not even on control of anything. For this, use the flag `do-not-evict-pod-controlled-by`; it can be repeated. An empty value means that we block eviction on pods that are uncontrolled.
-The value can be a `kind` or a `kind.group` or a `kind.version.group` to designate the owner resource type. If the `version` or/and the `group` are omitted it acts as a wildcard (any version, any group). It is case-sensitive and must match the API Resource definition.
+or not even under the control of any controller. For this, use the flag `do-not-evict-pod-controlled-by`; it can be repeated. An empty value means that we block eviction on pods that are uncontrolled.
+The value can be a `kind` or a `kind.group` or a `kind.version.group` to designate the owner resource type. If the `version` or/and the `group` are omitted it acts as a wildcard (any version, any group). It is case-sensitive and must match the API Resource definition. See documentation of [ParseKindArg](https://godoc.org/k8s.io/apimachinery/pkg/runtime/schema#ParseKindArg) for more details.
 
 Example:
 ```shell script
@@ -107,8 +107,6 @@ Keep the following in mind before deploying Draino:
 * Pods that can't be evicted by the cluster-autoscaler won't be evicted by draino.
   See annotation `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"` in
   [cluster-autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node)
-
-
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -36,25 +36,29 @@ Flags:
       --max-grace-period=8m0s    Maximum time evicted pods will be given to terminate gracefully.
       --eviction-headroom=30s    Additional time to wait after a pod's termination grace period for it to have been deleted.
       --drain-buffer=10m0s       Minimum time between starting each drain. Nodes are always cordoned immediately.
-      --node-label="foo=bar"     (DEPRECATED) Only nodes with this label will be eligible for cordoning and draining. May be specified multiple times.
-      --node-label-expr="metadata.labels.foo == 'bar'"
-                                 This is an expr string https://github.com/antonmedv/expr that must return true or false. See `nodefilters_test.go` for examples
-      --namespace="kube-system"  Namespace used to create leader election lock object.	
-      --leader-election-lease-duration=15s
+      --node-label=NODE-LABEL ...  
+                                 (Deprecated) Nodes with this label will be eligible for cordoning and draining. May be specified multiple times
+      --node-label-expr=NODE-LABEL-EXPR  
+                                 Nodes that match this expression will be eligible for cordoning and draining.
+      --namespace="kube-system"  Namespace used to create leader election lock object.
+      --leader-election-lease-duration=15s  
                                  Lease duration for leader election.
-      --leader-election-renew-deadline=10s
+      --leader-election-renew-deadline=10s  
                                  Leader election renew deadline.
-      --leader-election-retry-period=2s
+      --leader-election-retry-period=2s  
                                  Leader election retry period.
+      --leader-election-token-name="draino"  
+                                 Leader election token name.
       --skip-drain               Whether to skip draining nodes after cordoning.
-      --evict-daemonset-pods     Evict pods that were created by an extant DaemonSet.
+      --do-not-evict-pod-controlled-by=kind[[.version].group] examples: StatefulSets StatefulSets.apps StatefulSets.v1.apps ...  
+                                 Do not evict pods that are controlled by the designated kind, empty VALUE for uncontrolled pods, May be specified multiple times.
       --evict-emptydir-pods      Evict pods with local storage, i.e. with emptyDir volumes.
-      --evict-unreplicated-pods  Evict pods that were not created by a replication controller.
-      --protected-pod-annotation=KEY[=VALUE] ...
+      --protected-pod-annotation=KEY[=VALUE] ...  
                                  Protect pods with this annotation from eviction. May be specified multiple times.
 
 Args:
   <node-conditions>  Nodes for which any of these conditions are true will be cordoned and drained.
+
 ```
 
 ### Labels and Label Expressions
@@ -69,6 +73,24 @@ An example of `--node-label-expr`:
 (metadata.labels.region == 'us-west-1' && metadata.labels.app == 'nginx') || (metadata.labels.region == 'us-west-2' && metadata.labels.app == 'nginx')
 ```
 
+### Ignore pod controlled by ...
+It is possible to prevent eviction of pods that are under control of:
+- daemonset
+- statefulset
+- Custom Resource
+- ...
+
+or not even on control of anything. For this, use the flag `do-not-evict-pod-controlled-by`; it can be repeated. An empty value means that we block eviction on pods that are uncontrolled.
+The value can be a `kind` or a `kind.group` or a `kind.version.group` to designate the owner resource type. If the `version` or/and the `group` are omitted it acts as a wildcard (any version, any group). It is case-sensitive and must match the API Resource definition.
+
+Example:
+```shell script
+        - --do-not-evict-controlled-by=StatefulSet
+        - --do-not-evict-controlled-by=DaemonSet
+        - --do-not-evict-controlled-by=ExtendedDaemonSet.v1alpha1.datadoghq.com
+        - --do-not-evict-controlled-by=
+```
+  
 ## Considerations
 Keep the following in mind before deploying Draino:
 
@@ -85,6 +107,8 @@ Keep the following in mind before deploying Draino:
 * Pods that can't be evicted by the cluster-autoscaler won't be evicted by draino.
   See annotation `"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"` in
   [cluster-autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node)
+
+
 
 ## Deployment
 

--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -30,6 +30,7 @@ import (
 	"go.opencensus.io/tag"
 	"go.uber.org/zap"
 	"gopkg.in/alecthomas/kingpin.v2"
+	"k8s.io/client-go/dynamic"
 	client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/leaderelection"
@@ -67,11 +68,9 @@ func main() {
 		leaderElectionRetryPeriod   = app.Flag("leader-election-retry-period", "Leader election retry period.").Default(DefaultLeaderElectionRetryPeriod.String()).Duration()
 		leaderElectionTokenName     = app.Flag("leader-election-token-name", "Leader election token name.").Default(kubernetes.Component).String()
 
-		skipDrain             = app.Flag("skip-drain", "Whether to skip draining nodes after cordoning.").Default("false").Bool()
-		evictDaemonSetPods    = app.Flag("evict-daemonset-pods", "Evict pods that were created by an extant DaemonSet.").Bool()
-		evictStatefulSetPods  = app.Flag("evict-statefulset-pods", "Evict pods that were created by an extant StatefulSet.").Bool()
-		evictLocalStoragePods = app.Flag("evict-emptydir-pods", "Evict pods with local storage, i.e. with emptyDir volumes.").Bool()
-		evictUnreplicatedPods = app.Flag("evict-unreplicated-pods", "Evict pods that were not created by a replication controller.").Bool()
+		skipDrain                 = app.Flag("skip-drain", "Whether to skip draining nodes after cordoning.").Default("false").Bool()
+		doNotEvictPodControlledBy = app.Flag("do-not-evict-pod-controlled-by", "Do not evict pods that are controlled by the designated kind, empty VALUE for uncontrolled pods, May be specified multiple times.").PlaceHolder("kind[[.version].group]] examples: StatefulSets StatefulSets.apps StatefulSets.apps.v1").Default("", kubernetes.KindStatefulSet, kubernetes.KindDaemonSet).Strings()
+		evictLocalStoragePods     = app.Flag("evict-emptydir-pods", "Evict pods with local storage, i.e. with emptyDir volumes.").Bool()
 
 		protectedPodAnnotations = app.Flag("protected-pod-annotation", "Protect pods with this annotation from eviction. May be specified multiple times.").PlaceHolder("KEY[=VALUE]").Strings()
 
@@ -145,15 +144,22 @@ func main() {
 	if !*evictLocalStoragePods {
 		pf = append(pf, kubernetes.LocalStoragePodFilter)
 	}
-	if !*evictUnreplicatedPods {
-		pf = append(pf, kubernetes.UnreplicatedPodFilter)
+
+	apiResources, err := kubernetes.GetAPIResourcesForGVK(cs, *doNotEvictPodControlledBy)
+	if err != nil {
+		kingpin.FatalIfError(err, "can't get resources for controlby filtering")
 	}
-	if !*evictDaemonSetPods {
-		pf = append(pf, kubernetes.NewDaemonSetPodFilter(cs))
+	if len(apiResources) > 0 {
+		for _, apiResource := range apiResources {
+			if apiResource == nil {
+				log.Info("Filtering pod the are uncontrolled")
+			} else {
+				log.Info("Filtering pod controlled by apiresource", zap.Any("apiresource", *apiResource))
+			}
+		}
+		pf = append(pf, kubernetes.NewPodControlledByFilter(dynamic.NewForConfigOrDie(c), apiResources))
 	}
-	if !*evictStatefulSetPods {
-		pf = append(pf, kubernetes.NewStatefulSetPodFilter(cs))
-	}
+
 	systemKnownAnnotations := []string{
 		"cluster-autoscaler.kubernetes.io/safe-to-evict=false", // https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node
 	}

--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -147,12 +147,12 @@ func main() {
 
 	apiResources, err := kubernetes.GetAPIResourcesForGVK(cs, *doNotEvictPodControlledBy)
 	if err != nil {
-		kingpin.FatalIfError(err, "can't get resources for controlby filtering")
+		kingpin.FatalIfError(err, "can't get resources for controlled-by filtering")
 	}
 	if len(apiResources) > 0 {
 		for _, apiResource := range apiResources {
 			if apiResource == nil {
-				log.Info("Filtering pod the are uncontrolled")
+				log.Info("Pod filtering is unconstrained by controller")
 			} else {
 				log.Info("Filtering pod controlled by apiresource", zap.Any("apiresource", *apiResource))
 			}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/antonmedv/expr v1.8.8
 	github.com/go-test/deep v1.0.1
+	github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d
 	github.com/julienschmidt/httprouter v1.1.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/oklog/run v1.0.0

--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -36,8 +36,8 @@ const (
 	DefaultMaxGracePeriod   time.Duration = 8 * time.Minute
 	DefaultEvictionOverhead time.Duration = 30 * time.Second
 
-	kindDaemonSet   = "DaemonSet"
-	kindStatefulSet = "StatefulSet"
+	KindDaemonSet   = "DaemonSet"
+	KindStatefulSet = "StatefulSet"
 
 	ConditionDrainedScheduled = "DrainScheduled"
 	DefaultSkipDrain          = false

--- a/internal/kubernetes/drainer_test.go
+++ b/internal/kubernetes/drainer_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
-	//"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 )
 

--- a/internal/kubernetes/drainer_test.go
+++ b/internal/kubernetes/drainer_test.go
@@ -27,8 +27,12 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+
+	//"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 )
 
@@ -74,6 +78,14 @@ func newFakeClientSet(rs ...reactor) kubernetes.Interface {
 		cs.AddReactor(r.verb, r.resource, r.Fn())
 	}
 	return cs
+}
+
+func newFakeDynamicClient(objects ...runtime.Object) dynamic.Interface {
+	scheme := runtime.NewScheme()
+	if err := fake.AddToScheme(scheme); err != nil {
+		return nil
+	}
+	return dynamicfake.NewSimpleDynamicClient(scheme, objects...)
 }
 
 func TestCordon(t *testing.T) {

--- a/internal/kubernetes/podfilters.go
+++ b/internal/kubernetes/podfilters.go
@@ -111,7 +111,6 @@ func UnprotectedPodFilter(annotations ...string) PodFilterFunc {
 
 // NewPodFilters returns a FilterFunc that returns true if all of the supplied
 // FilterFuncs return true.
-
 func NewPodFilters(filters ...PodFilterFunc) PodFilterFunc {
 	return func(p core.Pod) (bool, error) {
 		for _, fn := range filters {

--- a/internal/kubernetes/util_test.go
+++ b/internal/kubernetes/util_test.go
@@ -67,7 +67,7 @@ var (
 	}
 
 	DaemonSetV1Apps = metav1.APIResource{
-		Name: "daemonsets",
+		Name:         "daemonsets",
 		SingularName: "daemonset",
 		Namespaced:   true,
 		Group:        "apps",
@@ -75,7 +75,7 @@ var (
 		Kind:         "DaemonSet",
 	}
 	StatefulSetSetV1Apps = metav1.APIResource{
-		Name: "statefulsets",
+		Name:         "statefulsets",
 		SingularName: "statefulset",
 		Namespaced:   true,
 		Group:        "apps",
@@ -83,7 +83,7 @@ var (
 		Kind:         "StatefulSet",
 	}
 	StatefulSetSetV1beta2Apps = metav1.APIResource{
-		Name: "statefulsets",
+		Name:         "statefulsets",
 		SingularName: "statefulset",
 		Namespaced:   true,
 		Group:        "apps",
@@ -202,18 +202,18 @@ func TestGetAPIResourcesForGVK(t *testing.T) {
 		{
 			name:    "statefulsets",
 			gvks:    []string{"StatefulSet"},
-			want:    []*metav1.APIResource{&StatefulSetSetV1Apps,&StatefulSetSetV1beta2Apps},
+			want:    []*metav1.APIResource{&StatefulSetSetV1Apps, &StatefulSetSetV1beta2Apps},
 			wantErr: false,
 		},
 		{
 			name:    "all",
-			gvks:    []string{"StatefulSet","DaemonSet","","ExtendedDaemonSet"},
-			want:    []*metav1.APIResource{nil,&StatefulSetSetV1Apps,&StatefulSetSetV1beta2Apps,&DaemonSetV1Apps,&ExtendedDaemonSetV1alpha1Datadog},
+			gvks:    []string{"StatefulSet", "DaemonSet", "", "ExtendedDaemonSet"},
+			want:    []*metav1.APIResource{nil, &StatefulSetSetV1Apps, &StatefulSetSetV1beta2Apps, &DaemonSetV1Apps, &ExtendedDaemonSetV1alpha1Datadog},
 			wantErr: false,
 		},
 		{
 			name:    "error not found",
-			gvks:    []string{"StatefulSet","DaemonSet","","ExtendedDaemonSet","Wrong"},
+			gvks:    []string{"StatefulSet", "DaemonSet", "", "ExtendedDaemonSet", "Wrong"},
 			want:    nil,
 			wantErr: true,
 		},

--- a/internal/kubernetes/util_test.go
+++ b/internal/kubernetes/util_test.go
@@ -1,0 +1,233 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+type fakeDiscoveryInterface struct {
+}
+
+func (f fakeDiscoveryInterface) ServerGroups() (*metav1.APIGroupList, error) {
+	return &metav1.APIGroupList{
+		Groups: []metav1.APIGroup{
+			{
+				Name: "apps",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{
+						GroupVersion: "apps/v1",
+						Version:      "v1",
+					},
+					{
+						GroupVersion: "apps/v1beta2",
+						Version:      "v1beta2",
+					},
+				},
+			},
+			{
+				Name: "",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{
+						GroupVersion: "v1",
+						Version:      "v1",
+					},
+				},
+			},
+			{
+				Name: "datadoghq.com",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{
+						GroupVersion: "datadoghq.com/v1",
+						Version:      "v1",
+					},
+					{
+						GroupVersion: "datadoghq.com/v1alpha1",
+						Version:      "v1alpha1",
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+var (
+	NodeV1Resource = metav1.APIResource{
+		Name:         "nodes",
+		SingularName: "node",
+		Namespaced:   false,
+		Group:        "",
+		Version:      "v1",
+		Kind:         "Node",
+	}
+
+	DaemonSetV1Apps = metav1.APIResource{
+		Name: "daemonsets",
+		SingularName: "daemonset",
+		Namespaced:   true,
+		Group:        "apps",
+		Version:      "v1",
+		Kind:         "DaemonSet",
+	}
+	StatefulSetSetV1Apps = metav1.APIResource{
+		Name: "statefulsets",
+		SingularName: "statefulset",
+		Namespaced:   true,
+		Group:        "apps",
+		Version:      "v1",
+		Kind:         "StatefulSet",
+	}
+	StatefulSetSetV1beta2Apps = metav1.APIResource{
+		Name: "statefulsets",
+		SingularName: "statefulset",
+		Namespaced:   true,
+		Group:        "apps",
+		Version:      "v1beta2",
+		Kind:         "StatefulSet",
+	}
+	ExtendedDaemonSetV1alpha1Datadog = metav1.APIResource{
+		Name:         "extendeddaemonsets",
+		SingularName: "extendeddaemonset",
+		Namespaced:   true,
+		Group:        "datadoghq.com",
+		Version:      "v1alpha1",
+		Kind:         "ExtendedDaemonSet",
+	}
+	ExtendedDaemonSetReplicaV1alpha1Datadog = metav1.APIResource{
+		Name:         "extendeddaemonsetreplicas",
+		SingularName: "extendeddaemonsetreplica",
+		Namespaced:   true,
+		Group:        "datadoghq.com",
+		Version:      "v1alpha1",
+		Kind:         "ExtendedDaemonSetReplica",
+	}
+)
+
+func (f fakeDiscoveryInterface) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+
+	switch groupVersion {
+	case "v1":
+		return &metav1.APIResourceList{
+			GroupVersion: groupVersion,
+			APIResources: []metav1.APIResource{NodeV1Resource},
+		}, nil
+	case "apps/v1":
+		return &metav1.APIResourceList{
+			GroupVersion: groupVersion,
+			APIResources: []metav1.APIResource{DaemonSetV1Apps, StatefulSetSetV1Apps},
+		}, nil
+	case "apps/v1beta2":
+		return &metav1.APIResourceList{
+			GroupVersion: groupVersion,
+			APIResources: []metav1.APIResource{StatefulSetSetV1beta2Apps},
+		}, nil
+	case "datadoghq.com/v1":
+		return &metav1.APIResourceList{}, nil
+	case "datadoghq.com/v1alpha1":
+		return &metav1.APIResourceList{
+			GroupVersion: groupVersion,
+			APIResources: []metav1.APIResource{ExtendedDaemonSetV1alpha1Datadog, ExtendedDaemonSetReplicaV1alpha1Datadog},
+		}, nil
+	}
+	return nil, nil
+}
+
+func (f fakeDiscoveryInterface) RESTClient() rest.Interface {
+	return nil // not needed
+}
+
+func (f fakeDiscoveryInterface) ServerResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil // not needed
+}
+
+func (f fakeDiscoveryInterface) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return nil, nil, nil // not needed
+}
+
+func (f fakeDiscoveryInterface) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil // not needed
+}
+
+func (f fakeDiscoveryInterface) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil // not needed
+}
+
+func (f fakeDiscoveryInterface) ServerVersion() (*version.Info, error) {
+	return nil, nil // not needed
+}
+
+func (f fakeDiscoveryInterface) OpenAPISchema() (*openapi_v2.Document, error) {
+	return nil, nil // not needed
+}
+
+func newFakeDiscoveryClient() discovery.DiscoveryInterface {
+	return &fakeDiscoveryInterface{}
+}
+
+func TestGetAPIResourcesForGVK(t *testing.T) {
+	tests := []struct {
+		name    string
+		gvks    []string
+		want    []*metav1.APIResource
+		wantErr bool
+	}{
+		{
+			name:    "empty case",
+			gvks:    []string{""},
+			want:    []*metav1.APIResource{nil},
+			wantErr: false,
+		},
+		{
+			name:    "nil case",
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "daemonset apps",
+			gvks:    []string{"DaemonSet.apps"},
+			want:    []*metav1.APIResource{&DaemonSetV1Apps},
+			wantErr: false,
+		},
+		{
+			name:    "daemonset apps v1",
+			gvks:    []string{"DaemonSet.v1.apps"},
+			want:    []*metav1.APIResource{&DaemonSetV1Apps},
+			wantErr: false,
+		},
+		{
+			name:    "statefulsets",
+			gvks:    []string{"StatefulSet"},
+			want:    []*metav1.APIResource{&StatefulSetSetV1Apps,&StatefulSetSetV1beta2Apps},
+			wantErr: false,
+		},
+		{
+			name:    "all",
+			gvks:    []string{"StatefulSet","DaemonSet","","ExtendedDaemonSet"},
+			want:    []*metav1.APIResource{nil,&StatefulSetSetV1Apps,&StatefulSetSetV1beta2Apps,&DaemonSetV1Apps,&ExtendedDaemonSetV1alpha1Datadog},
+			wantErr: false,
+		},
+		{
+			name:    "error not found",
+			gvks:    []string{"StatefulSet","DaemonSet","","ExtendedDaemonSet","Wrong"},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetAPIResourcesForGVK(newFakeDiscoveryClient(), tt.gvks)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetAPIResourcesForGVK() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAPIResourcesForGVK() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fix issue #98 

It is now possible to define eviction exclusion based on the pod ownerReference type. This open the door for more control on pods that are controlled by CRD.

example:
```
        --do-not-evict-pod-controlled-by=StatefulSet
        --do-not-evict-pod-controlled-by=DaemonSet
        --do-not-evict-pod-controlled-by=ExtendedDaemonSet
        --do-not-evict-pod-controlled-by=
```

This set of flags replace previous flag:
```
       --evict-daemonset-pods=false
       --evict-statefulset-pods=false
       --evict-unreplicated-pods=false
```
and adds an exclusion on `kind=ExtendedDaemonSet`

The default values have been set to match historical behavior.
