### PR TITLE
update draino helm image tag

### DIFF
--- a/helm/draino/values.yaml
+++ b/helm/draino/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: planetlabs/draino
-  tag: 2c3d2b4
+  tag: 450a853
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
Issue: https://github.com/planetlabs/draino/issues/100

Current default image tag has `read-only file system` issues as described in issue.