### PR TITLE
fail to start if node-label is provided twice with the same key - issue #107

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -58,7 +58,7 @@ func main() {
 		maxGracePeriod   = app.Flag("max-grace-period", "Maximum time evicted pods will be given to terminate gracefully.").Default(kubernetes.DefaultMaxGracePeriod.String()).Duration()
 		evictionHeadroom = app.Flag("eviction-headroom", "Additional time to wait after a pod's termination grace period for it to have been deleted.").Default(kubernetes.DefaultEvictionOverhead.String()).Duration()
 		drainBuffer      = app.Flag("drain-buffer", "Minimum time between starting each drain. Nodes are always cordoned immediately.").Default(kubernetes.DefaultDrainBuffer.String()).Duration()
-		nodeLabels       = app.Flag("node-label", "(Deprecated) Nodes with this label will be eligible for cordoning and draining. May be specified multiple times").StringMap()
+		nodeLabels       = app.Flag("node-label", "(Deprecated) Nodes with this label will be eligible for cordoning and draining. May be specified multiple times").Strings()
 		nodeLabelsExpr   = app.Flag("node-label-expr", "Nodes that match this expression will be eligible for cordoning and draining.").String()
 		namespace        = app.Flag("namespace", "Namespace used to create leader election lock object.").Default("kube-system").String()
 
@@ -188,8 +188,9 @@ func main() {
 		if *nodeLabelsExpr != "" {
 			kingpin.Fatalf("nodeLabels and NodeLabelsExpr cannot both be set")
 		}
-
-		nodeLabelsExpr = kubernetes.ConvertLabelsToFilterExpr(*nodeLabels)
+		if nodeLabelsExpr, err = kubernetes.ConvertLabelsToFilterExpr(*nodeLabels); err != nil {
+			kingpin.Fatalf(err.Error())
+		}
 	}
 
 	var nodeLabelFilter cache.ResourceEventHandler

--- a/internal/kubernetes/nodefilters.go
+++ b/internal/kubernetes/nodefilters.go
@@ -108,9 +108,18 @@ func (processed NodeProcessed) Filter(o interface{}) bool {
 }
 
 // ConvertLabelsToFilterExpr Convert old list labels into new expression syntax
-func ConvertLabelsToFilterExpr(labels map[string]string) *string {
+func ConvertLabelsToFilterExpr(labelsSlice []string) (*string, error) {
+	labels := map[string]string{}
+	for _, label := range labelsSlice {
+		tokens := strings.SplitN(label, "=", 2)
+		key := tokens[0]
+		value := tokens[1]
+		if v, found := labels[key]; found && v != value {
+			return nil, fmt.Errorf("node-label parameter is used twice with the same key and different values: '%s' , '%s", v, value)
+		}
+		labels[key] = value
+	}
 	res := []string{}
-
 	//sort the maps so that the unit tests actually work
 	keys := make([]string, 0, len(labels))
 	for k := range labels {
@@ -126,5 +135,5 @@ func ConvertLabelsToFilterExpr(labels map[string]string) *string {
 		}
 	}
 	temp := strings.Join(res, " && ")
-	return &temp
+	return &temp, nil
 }


### PR DESCRIPTION
Fix #107
Draino will exit with error and not fail silently if the same key is provided twice in the `node-label` parameter that does a AND in case it is provided multiple times.