### PR TITLE
feat(monitoring): add servicemonitor

### DIFF
--- a/helm/draino/templates/clusterrole.yaml
+++ b/helm/draino/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "draino.fullname" . }}

--- a/helm/draino/templates/clusterrolebinding.yaml
+++ b/helm/draino/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "draino.fullname" . }}

--- a/helm/draino/templates/service.yaml
+++ b/helm/draino/templates/service.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.service }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "draino.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "draino.name" . }}
+    helm.sh/chart: {{ include "draino.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+spec:
+  type: {{ default "ClusterIP" .Values.service.type }}
+  ports:
+    - name: draino-port
+      port: {{ default "9121" .Values.service.port }}
+      targetPort: 10002
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: {{ include "draino.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/draino/templates/servicemonitor.yaml
+++ b/helm/draino/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.serviceMonitor }}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "draino.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: {{ .Values.service.port }}
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+    path: /metrics
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
+{{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+{{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
+  jobLabel: {{ template "draino.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "draino.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.serviceMonitor.targetLabels }}
+  targetLabels:
+{{- range .Values.serviceMonitor.targetLabels }}
+    - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/draino/values.yaml
+++ b/helm/draino/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 
 image:
   repository: planetlabs/draino
-  tag: 450a853
+  tag: e0d5277
   pullPolicy: IfNotPresent
 
 resources:

--- a/helm/draino/values.yaml
+++ b/helm/draino/values.yaml
@@ -50,3 +50,26 @@ securityContext:
 containerSecurityContext:
   privileged: false
   readOnlyRootFilesystem: true
+
+# service:
+#   type: ClusterIP
+#   port: 9121
+#   annotations: {}
+#   labels: {}
+
+serviceMonitor:
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  # See: https://github.com/prometheus-community/helm-charts/blob/b68322246d01254aa6cc7d06c69034062c2157b7/charts/kube-prometheus-stack/values.yaml#L1825
+  labels: {}
+  #  prometheus: kube-prometheus
+  # Set the namespace the ServiceMonitor should be deployed
+  # namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  # interval: 15s
+  # Set timeout for scrape
+  # timeout: 10s
+  # Set of labels to transfer on the Kubernetes Service onto the target.
+  # targetLabels: []
+  # metricRelabelings: []


### PR DESCRIPTION
Allow to enable ServiceMonitor to expose metrics to Prometheus when Prometheus-Operator is installed.