### PR TITLE
Add serviceMonitor to expose metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@
 *.so
 *.dylib
 
-draino
-
 # Test binary, build with `go test -c`
 *.test
 

--- a/helm/draino/templates/clusterrole.yaml
+++ b/helm/draino/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "draino.fullname" . }}

--- a/helm/draino/templates/clusterrolebinding.yaml
+++ b/helm/draino/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "draino.fullname" . }}

--- a/helm/draino/templates/deployment.yaml
+++ b/helm/draino/templates/deployment.yaml
@@ -41,6 +41,11 @@ spec:
           {{- range .Values.conditions }}
             - {{ . }}
           {{- end }}
+          {{- if .Values.serviceMonitor.enabled }}
+          ports:
+            - name: metrics
+              containerPort: 10002
+          {{- end }}
           livenessProbe:
             initialDelaySeconds: 30
             httpGet:

--- a/helm/draino/templates/servicemonitor.yaml
+++ b/helm/draino/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceMonitor.enabled  }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "draino.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "draino.name" . }}
+    helm.sh/chart: {{ include "draino.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+    {{ toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: metrics
+      {{- if .Values.serviceMonitor.interval }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "draino.name" . }}
+{{- end }}

--- a/helm/draino/templates/svc.yaml
+++ b/helm/draino/templates/svc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "draino.name" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "draino.name" . }}
+    helm.sh/chart: {{ include "draino.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ template "draino.name" . }}
+  ports:
+  - port: 10002
+    targetPort: 10002
+{{- end }}

--- a/helm/draino/values.yaml
+++ b/helm/draino/values.yaml
@@ -10,7 +10,7 @@ image:
   repository: planetlabs/draino
   tag: 450a853
   pullPolicy: IfNotPresent
-
+  
 resources:
   limits:
     cpu: 100m
@@ -32,6 +32,12 @@ podLabels: {}
 rbac:
   create: true
   serviceAccountName:
+
+serviceMonitor:
+  enabled: false
+  additionalLabels: {}
+  interval: 30s
+  scrapeTimeout: 30s
 
 nodeSelector: {}
 


### PR DESCRIPTION
Hi 

I create a PR that create a serviceMonitor and a service to expose metrics and allow scrape to prometheus. 
Also i was change the `apiVersion` to stable, the v1beta1 are deprecated on k8s 1.17+ 

Thanks