### PR TITLE
rbac modifications for permission issues

### DIFF
--- a/internal/kubernetes/nodefilters_test.go
+++ b/internal/kubernetes/nodefilters_test.go
@@ -349,6 +349,10 @@ func TestOldNodeLabelFilter(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			labelExpr, err := ConvertLabelsToFilterExpr(tc.labels)
+			if err != nil {
+				t.Errorf("Label expression: %v, did not converted", err)
+				t.FailNow()
+			}
 
 			filter, err := NewNodeLabelFilter(labelExpr, log)
 			if err != nil {

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,36 +1,47 @@
 ---
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels: {component: draino}
   name: draino
   namespace: kube-system
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels: {component: draino}
+  labels:
+    component: draino
   name: draino
 rules:
-- apiGroups: ['']
-  resources: [events]
-  verbs: [create, patch, update]
-- apiGroups: ['']
-  resources: [nodes]
-  verbs: [get, watch, list, update]
-- apiGroups: ['']
-  resources: [nodes/status]
-  verbs: [patch]
-- apiGroups: ['']
-  resources: [pods]
-  verbs: [get, watch, list]
-- apiGroups: ['']
-  resources: [pods/eviction]
-  verbs: [create]
-- apiGroups: [extensions]
-  resources: [daemonsets]
-  verbs: [get, watch, list]
+  - apiGroups: ['']
+    resources: [events]
+    verbs: [create, patch, update]
+  - apiGroups: ['']
+    resources: [nodes]
+    verbs: [get, watch, list, update, patch]
+  - apiGroups: ['']
+    resources: [nodes/status]
+    verbs: [get, watch, list, update, patch]
+  - apiGroups: ['']
+    resources: [endpoints]
+    verbs: [get, watch, list, create, patch, update]
+  - apiGroups: ['']
+    resources: [pods]
+    verbs: [get, watch, list]
+  - apiGroups: ['']
+    resources: [pods/eviction]
+    verbs: [create]
+  - apiGroups:
+      - extensions
+      - apps
+    resources: [daemonsets]
+    verbs: [get, watch, list]
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -39,7 +50,9 @@ metadata:
 roleRef: {apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: draino}
 subjects:
 - {kind: ServiceAccount, name: draino, namespace: kube-system}
+
 ---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
This PR fixes #92 and #51. There are couple of duplicated issues for that problem.

Draino fails when deployed with the [manifest.yml](manifest.yml) in the repository. I have fixed the missing verbs in `ClusterRole`.

I have also fixed the golangci-lint error while linting the code.