### PR TITLE
add missing flags in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ Flags:
                                  Leader election renew deadline.
       --leader-election-retry-period=2s
                                  Leader election retry period.
+      --leader-election-token-name=draino
+                                 Leader election token name.
       --skip-drain               Whether to skip draining nodes after cordoning.
       --evict-daemonset-pods     Evict pods that were created by an extant DaemonSet.
+      --evict-statefulset-pods   Evict pods that were created by an extant StatefulSet.
       --evict-emptydir-pods      Evict pods with local storage, i.e. with emptyDir volumes.
       --evict-unreplicated-pods  Evict pods that were not created by a replication controller.
       --protected-pod-annotation=KEY[=VALUE] ...


### PR DESCRIPTION
Signed-off-by: yogeek <gdupin@gmail.com>

`evict-statefulset-pods` and `leader-election-token-name` options were missing from the flags listed in the documentation.
This PR aims to add them.